### PR TITLE
PR: Modifications fiches principalement p/r au logo

### DIFF
--- a/fiches/latex/fiches-rsesq.cls
+++ b/fiches/latex/fiches-rsesq.cls
@@ -113,10 +113,12 @@
       \fontsize{18}{24}\color{textheader}%
       {\bodyfont \thepage~de~\pageref{LastPage}}
     };
-    \node [anchor=north west, xshift=1cm] (note) at (box.south west) {%
-      \notefont{Créé le 2021-04-28, MELCC, Direction de l'eau potable et des 
-                eaux souterraines}
-    };
+    \ifnum \thepage=1 {%
+      \node [anchor=north west, xshift=1cm] (note) at (box.south west) {%
+        \notefont{Créé le 2021-04-28, MELCC, Direction de l'eau potable et des 
+                  eaux souterraines}
+      };
+    }\fi
   \end{tikzpicture}
 }
 

--- a/fiches/latex/fiches-rsesq.cls
+++ b/fiches/latex/fiches-rsesq.cls
@@ -99,11 +99,18 @@
     \node [rectangle, fill=fillheader, anchor=south west, minimum 
     width=\paperwidth, minimum height=1.75cm, yshift=1cm] (box) at (current 
     page.south west){};
-    \node [anchor=west][xshift=1cm] (logo) at (box.west) {%
-      {\includegraphics[height=0.9cm]{./signature-PIV.pdf}}
-    };
-    \node [anchor=east][xshift=-1cm] (page) at (box.east) {%
-      \fontsize{14}{24}\color{textheader}%
+    \ifnum \thepage=1 {%
+      \node [anchor=east][xshift=-1cm] (logo) at (box.east) {%
+        {\includegraphics[height=0.9cm]{./signature-PIV.pdf}}
+      };
+    }\fi
+    \ifnum \thepage=\pageref{LastPage} {%
+      \node [anchor=west][xshift=1cm] (logo) at (box.west) {%
+        {\includegraphics[height=0.9cm]{./signature-PIV.pdf}}
+      };
+    }\fi
+    \node [anchor=center][xshift=0cm] (page) at (box.center) {%
+      \fontsize{18}{24}\color{textheader}%
       {\bodyfont \thepage~de~\pageref{LastPage}}
     };
     \node [anchor=north west, xshift=1cm] (note) at (box.south west) {%

--- a/fiches/latex/fiches-rsesq.cls
+++ b/fiches/latex/fiches-rsesq.cls
@@ -102,9 +102,6 @@
     \node [anchor=west][xshift=1cm] (logo) at (box.west) {%
       {\includegraphics[height=0.9cm]{./signature-PIV.pdf}}
     };
-    \node [align=left, anchor=west, text width=\paperwidth][xshift=0.5cm] (name1) at (logo.east) {%
-      \fontsize{12}{14}\color{textheader}\bodyfont {Environnement et Lutte \\ contre les changements climatiques}
-    };
     \node [anchor=east][xshift=-1cm] (page) at (box.east) {%
       \fontsize{14}{24}\color{textheader}%
       {\bodyfont \thepage~de~\pageref{LastPage}}

--- a/fiches/latex/fiches-rsesq.cls
+++ b/fiches/latex/fiches-rsesq.cls
@@ -20,7 +20,7 @@
 \newcommand{\classleftmargin}{1cm}
 \newcommand{\classrightmargin}{1cm}
 \newcommand{\classtopmargin}{4cm}
-\newcommand{\classbottommargin}{3.25cm}
+\newcommand{\classbottommargin}{3.75cm}
 \newcommand{\classpaperheight}{11in}
 \newcommand{\classpaperwidth}{8.5in}
 
@@ -96,7 +96,9 @@
 
 \newcommand{\footer}[0]{%
   \begin{tikzpicture}[remember picture, overlay]
-    \node [rectangle, fill=fillheader, anchor=south west, minimum width=\paperwidth, minimum height=1.25cm, yshift=1cm] (box) at (current page.south west){};
+    \node [rectangle, fill=fillheader, anchor=south west, minimum 
+    width=\paperwidth, minimum height=1.75cm, yshift=1cm] (box) at (current 
+    page.south west){};
     \node [anchor=west][xshift=1cm] (logo) at (box.west) {%
       {\includegraphics[height=0.9cm]{./signature-PIV.pdf}}
     };

--- a/fiches/latex/fiches-rsesq.cls
+++ b/fiches/latex/fiches-rsesq.cls
@@ -19,7 +19,7 @@
 
 \newcommand{\classleftmargin}{1cm}
 \newcommand{\classrightmargin}{1cm}
-\newcommand{\classtopmargin}{4.5cm}
+\newcommand{\classtopmargin}{4cm}
 \newcommand{\classbottommargin}{3.25cm}
 \newcommand{\classpaperheight}{11in}
 \newcommand{\classpaperwidth}{8.5in}
@@ -81,16 +81,14 @@
 %\fancyhf{}
 %\renewcommand{\headrulewidth}{0pt}
 
-\newcommand{\header}[2]{%
+\newcommand{\header}[1]{%
   \begin{tikzpicture}[remember picture, overlay]
-    \node [rectangle, fill=fillheader, anchor=north, minimum width=\paperwidth, minimum height=2.5cm, yshift=-1cm] (box) at (current page.north){};
-    \node [anchor=center, yshift=8pt] (name) at (box) {%
+    \node [rectangle, fill=fillheader, anchor=north, minimum 
+    width=\paperwidth, minimum height=2cm, yshift=-1cm] (box) at (current 
+    page.north){};
+    \node [anchor=center, yshift=0pt] (name) at (box) {%
       \fontsize{40pt}{72pt}\color{textheader}%
       \bodyfont Station #1
-    };
-    \node [anchor=north] at (name.south) {%
-      \fontsize{16pt}{24pt}\color{textheader}%
-      \thinfont Municipalité de #2%
     };
   \end{tikzpicture}
   \vspace{-2em}
@@ -117,9 +115,9 @@
 }
 
 \RequirePackage{atbegshi}
-\newcommand{\createfooterheader}[2]{%
+\newcommand{\createfooterheader}[1]{%
     \AtBeginShipout{\AtBeginShipoutAddToBox{%
-      \header{#1}{#2}
+      \header{#1}
       \footer
     }}
 }

--- a/fiches/latex/fiches-rsesq.tex
+++ b/fiches/latex/fiches-rsesq.tex
@@ -39,7 +39,7 @@
 
 \input{fiches-rsesq-station}
 
-\createfooterheader{\stationid}{\munname}
+\createfooterheader{\stationid}
 \begin{document}
 \inputpageone{}
 \inputpagetwo{}

--- a/scripts/standards_indexes_monthly/calc_std_indexes_v2.py
+++ b/scripts/standards_indexes_monthly/calc_std_indexes_v2.py
@@ -170,6 +170,7 @@ precip_win = 6
 
 figures_stack = []
 std_indexes_stack = []
+staname_stack = []
 # for staname in selected_stations:
 for staname in ['03040018']:
     std_indexes, figures = calc_std_indexes(
@@ -178,19 +179,25 @@ for staname in ['03040018']:
         wlvl_win=wlvl_win)
     figures_stack.append(figures)
     std_indexes_stack.append(std_indexes)
+    staname_stack.append(staname)
 
 DIRNAME = osp.join(osp.dirname(__file__), 'results_std_indexes')
 os.makedirs(DIRNAME, exist_ok=True)
 
 FILENAMES = [
-    f'(spli{wlvl_win}_spi{precip_win}) spi_vs_spli.pdf',
-    f'(spli{wlvl_win}_spi{precip_win}) pdf_niveau.pdf',
-    f'(spli{wlvl_win}_spi{precip_win}) pdf_precip.pdf',
-    f'(spli{wlvl_win}_spi{precip_win}) correlation_croisee.pdf',
-    f'(spli{wlvl_win}_spi{precip_win}) spli_vs_classes.pdf']
+    f'(spli{wlvl_win}_spi{precip_win}) spi_vs_spli',
+    f'(spli{wlvl_win}_spi{precip_win}) pdf_niveau',
+    f'(spli{wlvl_win}_spi{precip_win}) pdf_precip',
+    f'(spli{wlvl_win}_spi{precip_win}) correlation_croisee',
+    f'(spli{wlvl_win}_spi{precip_win}) spli_vs_classes']
+
+for figures, staname in zip(figures_stack, staname_stack):
+    for fig, filename in zip(figures, FILENAMES):
+        fig.savefig(osp.join(
+            DIRNAME, staname + '_' + filename + '.svg'))
+
 for i, filename in enumerate(FILENAMES):
-    filepath = osp.join(DIRNAME, filename)
-    with PdfPages(filepath) as pdf:
+    with PdfPages(osp.join(DIRNAME, filename + '.pdf')) as pdf:
         for figures in figures_stack:
             pdf.savefig(figures[i])
 


### PR DESCRIPTION
Modifications demandés par le ministère p/r à la mise en page des fiches.

- Logo seulement sur première et dernière page
- Logo à droite sur la première page et à gauche sur la dernière
- Bande du bas plus haute (pour laisser plus de place au logo)
- J'ai enlevé le texte à côté du logo
- j'ai enlevé le nom de la municipalité dans la bande du haut.
- J'ai laissé le texte qui donne la date de création de la fiche, mais seulement sur la première page.
- J'ai déplacé le numéro de page au centre de la page et augmenté la taille de la police

![image](https://user-images.githubusercontent.com/10170372/160902275-3980c9b4-5353-49ae-94c7-ea8694dd5c9b.png)

![image](https://user-images.githubusercontent.com/10170372/160902321-57266c39-25cc-466f-ae9c-963d2f6e5bac.png)

![image](https://user-images.githubusercontent.com/10170372/160902350-55e43541-8239-425e-a28e-deefe0fde198.png)

